### PR TITLE
Add support for parsing and handling dates and times in tasks

### DIFF
--- a/src/main/java/Deadline.java
+++ b/src/main/java/Deadline.java
@@ -1,23 +1,26 @@
-public class Deadline extends Task{
-    protected String by;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
-    public Deadline(String description, String by) {
+public class Deadline extends Task {
+    private final LocalDateTime by;
+
+    public Deadline(String description, LocalDateTime by) {
         super(description);
         this.by = by;
     }
 
-    public Deadline(String description, String by, boolean isDone) {
+    public Deadline(String description, LocalDateTime by, boolean isDone) {
         super(description, isDone);
         this.by = by;
     }
 
-    @Override
-    public String toFileFormat() {
-        return "D | " + (isDone ? "1" : "0") + " | " + description + " | " + by;
+    @Override public String toFileFormat() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HHmm");
+        return "D | " + (isDone ? "1" : "0") + " | " + description + " | " + by.format(formatter);
     }
 
-    @Override
-    public String toString() {
-        return "[D]" + super.toString() + " (by: " + by + ")";
+    @Override public String toString() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MMM d yyyy, h:mm a");
+        return "[D]" + super.toString() + " (by: " + by.format(formatter) + ")";
     }
 }

--- a/src/main/java/Event.java
+++ b/src/main/java/Event.java
@@ -1,26 +1,30 @@
-public class Event extends Task{
-    protected String from;
-    protected String to;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
-    public Event(String description, String from, String to) {
+public class Event extends Task {
+    protected LocalDateTime from;
+    protected LocalDateTime to;
+
+    public Event(String description, LocalDateTime from, LocalDateTime to) {
         super(description);
         this.from = from;
         this.to = to;
     }
 
-    public Event(String description, String from, String to, boolean isDone) {
+    public Event(String description, LocalDateTime from, LocalDateTime to, boolean isDone) {
         super(description, isDone);
         this.from = from;
         this.to = to;
     }
 
-    @Override
-    public String toFileFormat() {
-        return "E | " + (isDone ? "1" : "0") + " | " + description + " | " + from + " | " + to;
+    @Override public String toFileFormat() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HHmm");
+        return "E | " + (isDone ? "1" : "0") + " | " + description + " | " + from.format(formatter) + " | " +
+                to.format(formatter);
     }
 
-    @Override
-    public String toString() {
-        return "[E]" + super.toString() + " (from: " + from + " to: " + to + ")";
+    @Override public String toString() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MMM d yyyy, h:mm a");
+        return "[E]" + super.toString() + " (from: " + from.format(formatter) + " to: " + to.format(formatter) + ")";
     }
 }


### PR DESCRIPTION
Tasks are currently stored with deadline dates as strings, which limits the ability to perform operations on dates and makes it harder to display dates in a user-friendly format.

Handling dates as strings makes it difficult to perform date comparisons, manipulations, and user-friendly formatting. Using a dedicated date type will enhance code clarity and maintainability.

Let's implement support for parsing dates and times using `java.time.LocalDate` and `java.time.LocalDateTime` in task objects. Accepted formats include `yyyy-mm-dd` (e.g., 2019-10-15). Dates will be displayed in a readable format such as "MMM dd yyyy" (e.g., Oct 15 2019).

Using the Java time package allows for more flexible and robust handling of dates and times, facilitating future enhancements such as filtering tasks by date and adding time-based reminders.